### PR TITLE
allow to create view cache with artisan

### DIFF
--- a/src/Providers/PagesServiceProvider.php
+++ b/src/Providers/PagesServiceProvider.php
@@ -58,7 +58,6 @@ class PagesServiceProvider extends ServiceProvider
     {
         // Load views
         $this->loadViewsFrom(self::PACKAGE_DIR . 'resources/views', 'voyager-pages');
-        $this->loadViewsFrom(self::PACKAGE_DIR . 'resources/views/vendor/voyager', 'voyager');
     }
 
     /**


### PR DESCRIPTION
just like voyager-blog package, voyager pages blocks creating view caches. there is no vendor directory and because of that cache cannot be created with artisan.